### PR TITLE
Game item datastructure

### DIFF
--- a/src/engine/ArmadaGame.java
+++ b/src/engine/ArmadaGame.java
@@ -2,7 +2,6 @@ package engine;
 
 import BBDGameLibrary.GameEngine.Camera;
 import BBDGameLibrary.GameEngine.GameComponent;
-import BBDGameLibrary.GameEngine.GameItem;
 import BBDGameLibrary.GameEngine.MouseInput;
 import BBDGameLibrary.Geometry2d.BBDPoint;
 import BBDGameLibrary.Geometry2d.BBDPolygon;
@@ -12,7 +11,6 @@ import engine.parsers.SquadronFactory;
 import gameComponents.DemoMap;
 import gameComponents.Squadrons.Squadron;
 import org.joml.Vector3f;
-import org.lwjgl.system.CallbackI;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -30,6 +28,7 @@ public class ArmadaGame implements GameComponent {
     private DemoMap demoMap;
 
     private ArrayList<Squadron> squadrons;
+    private GameItemSorter itemsToRender = new GameItemSorter();
 
     /**
      * A basic constructor.  Sets up the items only need one instance that is then shared between objects
@@ -48,6 +47,7 @@ public class ArmadaGame implements GameComponent {
     public void init(Window window) {
 
         demoMap = initializeDemoMap();
+        this.itemsToRender.addItems(demoMap);
 
         //Temporary - just list out all the squadrons and show them all
         squadrons = new ArrayList<>();
@@ -67,6 +67,7 @@ public class ArmadaGame implements GameComponent {
                 currentCol++;
                 System.out.println(temp.getLocation());
                 squadrons.add(temp);
+                this.itemsToRender.addItems(temp.getGameItems());
             }
 
         } catch (FileNotFoundException e) {
@@ -113,11 +114,9 @@ public class ArmadaGame implements GameComponent {
     @Override
     public void render(Window window) {
         renderer.resetRenderer(window);
-        renderer.renderItem(window, demoMap, camera);
-        for(Squadron squadron: squadrons){
-            for(GameItem item: squadron.getGameItems()){
-                renderer.renderItem(window, item, camera);
-            }
+        for(int i = 0; i < this.itemsToRender.getItemCount(); i++){
+            renderer.renderItem(window, this.itemsToRender.getItem(i), camera);
+            //System.out.println(this.itemsToRender.getItem(i).getPosition());
         }
     }
 
@@ -140,6 +139,6 @@ public class ArmadaGame implements GameComponent {
         ShaderProgram shader = Utils.buildBasicTexturedShaderProgram();
         Texture texture = new Texture("assets/images/maps/map1.jpg");
 
-        return new DemoMap(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.MAP_BACKGROUND_LAYER, true);
+        return new DemoMap(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.LAYER_MAP_BACKGROUND, true);
     }
 }

--- a/src/engine/GameConstants.java
+++ b/src/engine/GameConstants.java
@@ -48,8 +48,8 @@ public class GameConstants {
     /**Layers, how far from the camera the associated items are drawn
      *
      */
-    public static final int SQUADRON_PLASTIC = 25;
-    public static final int SQUADRON_CARDBOARD = 24;
-    public static final int SQUADRON_GRAPHIC = 22;
-    public static final int MAP_BACKGROUND_LAYER = 20000;
+    public static final int LAYER_SQUADRON_PLASTIC = 25;
+    public static final int LAYER_SQUADRON_CARDBOARD = 23;
+    public static final int LAYER_SQUADRON_GRAPHIC = 22;
+    public static final int LAYER_MAP_BACKGROUND = 26;
 }

--- a/src/engine/GameItemSorter.java
+++ b/src/engine/GameItemSorter.java
@@ -1,0 +1,49 @@
+package engine;
+
+import BBDGameLibrary.GameEngine.GameItem2d;
+
+import java.util.ArrayList;
+
+public class GameItemSorter {
+
+    private ArrayList<GameItem2d> items = new ArrayList<>();
+
+    public void addItems(ArrayList<GameItem2d> items){
+        for(GameItem2d item: items){
+            insertItem(item);
+        }
+    }
+
+    public void addItems(GameItem2d item){
+        insertItem(item);
+    }
+
+    public void addItems(GameItemSorter sorter){
+        for(GameItem2d item:sorter.items){
+            insertItem(item);
+        }
+    }
+
+    public int getItemCount(){
+        return this.items.size();
+    }
+
+    public GameItem2d getItem(int index){
+        return this.items.get(index);
+    }
+
+    private void insertItem(GameItem2d newItem){
+        int insertIndex = -1;
+        for (int i = 0; i<this.items.size(); i++){
+            if (this.items.get(i).getLayer() > newItem.getLayer()){
+                insertIndex = i;
+                break;
+            }
+        }
+        if(insertIndex == -1){
+            this.items.add(newItem);
+        }else {
+            this.items.add(insertIndex, newItem);
+        }
+    }
+}

--- a/src/gameComponents/Squadrons/Squadron.java
+++ b/src/gameComponents/Squadrons/Squadron.java
@@ -12,10 +12,10 @@ import BBDGameLibrary.OpenGL.ShaderProgram;
 import BBDGameLibrary.OpenGL.Texture;
 import BBDGameLibrary.OpenGL.Window;
 import engine.GameConstants;
+import engine.GameItemSorter;
 import engine.Utils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 
 /**
  * A class representing a Squadron object
@@ -33,7 +33,7 @@ public class Squadron implements GameComponent {
     private final ArrayList<String> keywords;
     private final int pointsValue;
     private ArrayList<String> defenseTokens;
-    private ArrayList<GameItem> gameItems = new ArrayList<>();
+    private GameItemSorter gameItems = new GameItemSorter();
     private BBDPoint currentLocation = new BBDPoint(0,0);
     private boolean renderSquadrons;
 
@@ -124,17 +124,17 @@ public class Squadron implements GameComponent {
         BBDPolygon plasticBase = BBDGeometryUtils.createCircle(this.currentLocation, GameConstants.SQUADRON_PLASTIC_RADIUS, 100);
         BBDPolygon cardboard = BBDGeometryUtils.createCircle(this.currentLocation, GameConstants.SQUADRON_CARDBOARD_RADIUS, 100);
 
-        GameItem plasticBaseItem = new GameItem2d(Mesh.buildMeshFromPolygon(plasticBase, null), engine.Utils.buildSolidColorShader("white"), plasticBase, GameConstants.SQUADRON_PLASTIC, true);
+        GameItem2d plasticBaseItem = new GameItem2d(Mesh.buildMeshFromPolygon(plasticBase, null), engine.Utils.buildSolidColorShader("white"), plasticBase, GameConstants.LAYER_SQUADRON_PLASTIC, true);
 
-        GameItem cardboardItem = new GameItem2d(Mesh.buildMeshFromPolygon(cardboard, null), engine.Utils.buildSolidColorShader("black"), cardboard, GameConstants.SQUADRON_CARDBOARD, true);
+        GameItem2d cardboardItem = new GameItem2d(Mesh.buildMeshFromPolygon(cardboard, null), engine.Utils.buildSolidColorShader("black"), cardboard, GameConstants.LAYER_SQUADRON_CARDBOARD, true);
 
         BBDPolygon poly = Utils.buildQuad(20, 20);
         ShaderProgram shader = Utils.buildBasicTexturedShaderProgram();
         Texture texture = new Texture("assets/images/squadrons/squad_"+buildSquadFileName());
-        GameItem squadronGraphic = new GameItem2d(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.SQUADRON_GRAPHIC, false);
-        this.gameItems.add(squadronGraphic);
-        this.gameItems.add(cardboardItem);
-        this.gameItems.add(plasticBaseItem);
+        GameItem2d squadronGraphic = new GameItem2d(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.LAYER_SQUADRON_GRAPHIC, false);
+        this.gameItems.addItems(squadronGraphic);
+        this.gameItems.addItems(cardboardItem);
+        this.gameItems.addItems(plasticBaseItem);
     }
 
     /**
@@ -162,10 +162,8 @@ public class Squadron implements GameComponent {
         this.currentLocation = newPoint;
         float newX = newPoint.getXLoc();
         float newY = newPoint.getYLoc();
-        if(this.renderSquadrons) {
-            for(GameItem gameItem:this.gameItems){
-                gameItem.setPosition(newX, newY, gameItem.getPosition().z);
-            }
+        for(int i =0; i<gameItems.getItemCount(); i++){
+            gameItems.getItem(i).setPosition(newX, newY, gameItems.getItem(i).getPosition().z);
         }
     }
 
@@ -243,7 +241,7 @@ public class Squadron implements GameComponent {
         return defenseTokens;
     }
 
-    public ArrayList<GameItem> getGameItems() {
+    public GameItemSorter getGameItems() {
         return gameItems;
     }
 

--- a/tests/GameItemSorterTests.java
+++ b/tests/GameItemSorterTests.java
@@ -1,0 +1,146 @@
+import BBDGameLibrary.GameEngine.GameItem;
+import BBDGameLibrary.GameEngine.GameItem2d;
+import BBDGameLibrary.Geometry2d.BBDPoint;
+import BBDGameLibrary.Geometry2d.BBDPolygon;
+import BBDGameLibrary.OpenGL.Mesh;
+import BBDGameLibrary.OpenGL.Window;
+import BBDGameLibrary.TestUtils;
+import engine.GameItemSorter;
+import engine.parsers.ParsingException;
+import engine.parsers.SquadronFactory;
+import gameComponents.Squadrons.Squadron;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileNotFoundException;
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class GameItemSorterTests {
+    Window window = null;
+    boolean windowInit = false;
+    public void initWindow(){
+        window = new Window("test", 5, 5, true, new Window.WindowOptions());
+        window.init();
+    }
+
+    public BBDPolygon buildSquare() {
+        BBDPoint point1 = new BBDPoint(1, 1);
+        BBDPoint point2 = new BBDPoint(1, -1);
+        BBDPoint point3 = new BBDPoint(-1, -1);
+        BBDPoint point4 = new BBDPoint(-1, 1);
+
+        ArrayList<BBDPoint> points = new ArrayList<>(Arrays.asList(point1, point2, point3, point4));
+
+        return new BBDPolygon(points);
+    }
+
+    public GameItem2d buildItem(int layer){
+        BBDPolygon poly = TestUtils.buildSquare();
+        Mesh mesh = Mesh.buildMeshFromPolygon(poly, null);
+
+        GameItem2d item = new GameItem2d(mesh, null, poly, layer, true);
+        return item;
+    }
+
+    @Test
+    public void testBuildList(){
+        if(!windowInit){
+            initWindow();
+        }
+
+        GameItem2d item1 = buildItem(1);
+        GameItem2d item2 = buildItem(2);
+        GameItem2d item3 = buildItem(3);
+
+        ArrayList<GameItem2d> itemList = new ArrayList<GameItem2d>();
+        itemList.add(item2);
+        itemList.add(item3);
+        itemList.add(item1);
+
+        GameItemSorter sorter = new GameItemSorter();
+        sorter.addItems(itemList);
+
+        //the items should be rearranged by layer, with the bigger numbers first
+        assertEquals(item1, sorter.getItem(0));
+        assertEquals(item2, sorter.getItem(1));
+        assertEquals(item3, sorter.getItem(2));
+    }
+
+    @Test
+    public void testBuildSorter(){
+        if(!windowInit){
+            initWindow();
+        }
+
+        GameItem2d item1 = buildItem(1);
+        GameItem2d item2 = buildItem(2);
+        GameItem2d item3 = buildItem(3);
+
+        ArrayList<GameItem2d> itemList = new ArrayList<GameItem2d>();
+        itemList.add(item2);
+        itemList.add(item3);
+        itemList.add(item1);
+
+        GameItemSorter sorter = new GameItemSorter();
+        sorter.addItems(itemList);
+        //borrowed from above test to build a sorter ^^^^^^
+
+        GameItemSorter newSorter = new GameItemSorter();
+        newSorter.addItems(sorter);
+        //the items should be rearranged by layer, with the bigger numbers first
+        assertEquals(item1, sorter.getItem(0));
+        assertEquals(item2, sorter.getItem(1));
+        assertEquals(item3, sorter.getItem(2));
+    }
+
+    @Test
+    public void testAddItem(){
+        if(!windowInit){
+            initWindow();
+        }
+
+        GameItem2d item1 = buildItem(1);
+        GameItem2d item2 = buildItem(2);
+        GameItem2d item4 = buildItem(4);
+
+        ArrayList<GameItem2d> itemList = new ArrayList<GameItem2d>();
+        itemList.add(item2);
+        itemList.add(item4);
+        itemList.add(item1);
+
+        GameItemSorter sorter = new GameItemSorter();
+        sorter.addItems(itemList);
+
+        GameItem2d item3 = buildItem(3);
+        sorter.addItems(item3);
+
+        assertEquals(item3, sorter.getItem(2));
+    }
+
+    @Test
+    public void testItemCount(){
+        if(!windowInit){
+            initWindow();
+        }
+
+        GameItem2d item1 = buildItem(1);
+        GameItem2d item2 = buildItem(2);
+        GameItem2d item4 = buildItem(4);
+
+        ArrayList<GameItem2d> itemList = new ArrayList<GameItem2d>();
+        itemList.add(item2);
+        itemList.add(item4);
+        itemList.add(item1);
+
+        GameItemSorter sorter = new GameItemSorter();
+        sorter.addItems(itemList);
+        assertEquals(3, sorter.getItemCount());
+
+        GameItem2d item3 = buildItem(3);
+        sorter.addItems(item3);
+
+        assertEquals(4, sorter.getItemCount());
+    }
+}


### PR DESCRIPTION
## Goal of Pull Request
Fairly hassle free way of ensuring that objects render in the right order.  It relies on each object being given a layer of similar objects.

Provides a simple data structure that takes in a variety of structures and sorts them appropriately.

## Potential Tasks

  - [x] Connects to #53
  - [x] Meets the DefDone of the linked issue
  - [x] All tests pass (Although the reviewer should run them to make sure)

## Any other pertinent information
OpenGL doesn't really pay attention to if an object *SHOULD* be obscured by a nearer object.  It mostly pays attention to what order it receives draw commands in.  In 2d games using OpenGL a common method is to sort by depth and use the "painters method" and do stuff far to near.  A simple value to sort by here is the layer value we have to pass into our GameItem2d objects.  That layer does have a small offset for the z axis, but nothing substantial, 1 layer is ~1 micron in real world units since we are doing units in mm.
