### PR TITLE
Recentralize DefenseToken enums

### DIFF
--- a/ArmadaAIEngineNew.iml
+++ b/ArmadaAIEngineNew.iml
@@ -27,5 +27,21 @@
       </library>
     </orderEntry>
     <orderEntry type="library" name="BBDGameLib" level="project" />
+    <orderEntry type="module-library" scope="TEST">
+      <library name="JUnit5.7.0">
+        <CLASSES>
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter/5.7.0/junit-jupiter-5.7.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-api/5.7.0/junit-jupiter-api-5.7.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/apiguardian/apiguardian-api/1.1.0/apiguardian-api-1.1.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/opentest4j/opentest4j/1.2.0/opentest4j-1.2.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-commons/1.7.0/junit-platform-commons-1.7.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-params/5.7.0/junit-jupiter-params-5.7.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/jupiter/junit-jupiter-engine/5.7.0/junit-jupiter-engine-5.7.0.jar!/" />
+          <root url="jar://$MAVEN_REPOSITORY$/org/junit/platform/junit-platform-engine/1.7.0/junit-platform-engine-1.7.0.jar!/" />
+        </CLASSES>
+        <JAVADOC />
+        <SOURCES />
+      </library>
+    </orderEntry>
   </component>
 </module>

--- a/src/engine/GameConstants.java
+++ b/src/engine/GameConstants.java
@@ -4,9 +4,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 
 public class GameConstants {
-    /**
-     * This is going to be a static class object to contain common values that need to be accessible across many
-     * different types of objects.
+    /*
+      This is going to be a static class object to contain common values that need to be accessible across many
+      different types of objects.
      */
 
     // Dimensions in millimeters
@@ -52,11 +52,5 @@ public class GameConstants {
     public static final int SQUADRON_CARDBOARD = 24;
     public static final int SQUADRON_GRAPHIC = 22;
     public static final int MAP_BACKGROUND_LAYER = 20000;
-
-    /**
-     *Defense Token Constants
-     */
-    public enum defenseTokenType {BRACE, REDIRECT, EVADE, SCATTER, CONTAIN, SALVO}
-    public enum defenseTokenStatus {READY, EXHAUSTED, DISCARDED}
 
 }

--- a/src/gameComponents/DefenseTokens/DefenseToken.java
+++ b/src/gameComponents/DefenseTokens/DefenseToken.java
@@ -10,22 +10,22 @@ public class DefenseToken {
     /**
      *Defense Token Constants
      */
-    public enum defenseTokenType {BRACE, REDIRECT, EVADE, SCATTER, CONTAIN, SALVO}
+    public enum Type {BRACE, REDIRECT, EVADE, SCATTER, CONTAIN, SALVO}
 
-    public enum defenseTokenStatus {READY, EXHAUSTED, DISCARDED}
+    public enum Status {READY, EXHAUSTED, DISCARDED}
 
     /**
      * Defense Token fields
      */
     //The type of token
-    private defenseTokenType type;
+    private Type type;
     //The status of the token. All defense tokens start in the ready state
-    private defenseTokenStatus status = defenseTokenStatus.READY;
+    private Status status = Status.READY;
 
     //No Null constructor
 
     //Typed Constructor
-    public DefenseToken(defenseTokenType type){
+    public DefenseToken(Type type){
         this.type = type;
     }
     //TODO: A String based constructor to use in ship/squadron parsers / factories
@@ -34,7 +34,7 @@ public class DefenseToken {
      * Generic getter method for token status
      * @return the status of the defense token
      */
-    public defenseTokenStatus getStatus(){
+    public Status getStatus(){
         return status;
     }
 
@@ -42,7 +42,7 @@ public class DefenseToken {
      * Generic getter for token type
      * @return the type of defense token
      */
-    public defenseTokenType getType(){
+    public Type getType(){
         return type;
     }
 
@@ -51,7 +51,7 @@ public class DefenseToken {
      * @return true if token status is ready, else false
      */
     public boolean isReady(){
-        return (status == defenseTokenStatus.READY);
+        return (status == Status.READY);
     }
 
     /**
@@ -59,7 +59,7 @@ public class DefenseToken {
      * @return true if token status is exhausted, else false
      */
     public boolean isExhausted(){
-        return (status == defenseTokenStatus.EXHAUSTED);
+        return (status == Status.EXHAUSTED);
     }
 
     /**
@@ -67,7 +67,7 @@ public class DefenseToken {
      * @return true if token status is discarded, else false
      */
     public boolean isDiscarded(){
-        return (status == defenseTokenStatus.DISCARDED);
+        return (status == Status.DISCARDED);
     }
 
     /**
@@ -75,7 +75,7 @@ public class DefenseToken {
      * @param status the status of the defense token
      * @return true if token status matches, else false
      */
-    public boolean isStatus(defenseTokenStatus status){
+    public boolean isStatus(Status status){
         return (this.status == status);
     }
 
@@ -84,7 +84,7 @@ public class DefenseToken {
      * @param type the type of defense token
      * @return true if token is the specified type, else false
      */
-    public boolean isType(defenseTokenType type){
+    public boolean isType(Type type){
         return (this.type == type);
     }
 
@@ -95,7 +95,7 @@ public class DefenseToken {
      */
     public boolean exhaust(){
         if(isReady()){
-            status = defenseTokenStatus.EXHAUSTED;
+            status = Status.EXHAUSTED;
             return true;
         } else {
             return false;
@@ -108,7 +108,7 @@ public class DefenseToken {
      */
     public boolean discard(){
         if(!isDiscarded()){
-            status = defenseTokenStatus.DISCARDED;
+            status = Status.DISCARDED;
             return true;
         } else {
             return false;
@@ -138,7 +138,7 @@ public class DefenseToken {
      */
     public boolean ready(){
         if(isExhausted()){
-            status = defenseTokenStatus.READY;
+            status = Status.READY;
             return true;
         } else {
             return false;
@@ -150,7 +150,7 @@ public class DefenseToken {
      */
     public boolean recover(){
         if(isDiscarded()) {
-            status = defenseTokenStatus.READY;
+            status = Status.READY;
             return true;
         } else {
             return false;

--- a/src/gameComponents/DefenseTokens/DefenseToken.java
+++ b/src/gameComponents/DefenseTokens/DefenseToken.java
@@ -1,23 +1,31 @@
 package gameComponents.DefenseTokens;
 
-import engine.GameConstants;
-
 public class DefenseToken {
-    /**
+    /*
     A defense Token is a token that can be assigned to squadrons or ships. A defense token has a variety of states
     The Defense token class allows for the creation of defense tokens and allows for the various state changes
     it may undergo during normal use
      */
 
+    /**
+     *Defense Token Constants
+     */
+    public enum defenseTokenType {BRACE, REDIRECT, EVADE, SCATTER, CONTAIN, SALVO}
+
+    public enum defenseTokenStatus {READY, EXHAUSTED, DISCARDED}
+
+    /**
+     * Defense Token fields
+     */
     //The type of token
-    private GameConstants.defenseTokenType type;
+    private defenseTokenType type;
     //The status of the token. All defense tokens start in the ready state
-    private GameConstants.defenseTokenStatus status = GameConstants.defenseTokenStatus.READY;
+    private defenseTokenStatus status = defenseTokenStatus.READY;
 
     //No Null constructor
 
     //Typed Constructor
-    public DefenseToken(GameConstants.defenseTokenType type){
+    public DefenseToken(defenseTokenType type){
         this.type = type;
     }
     //TODO: A String based constructor to use in ship/squadron parsers / factories
@@ -26,7 +34,7 @@ public class DefenseToken {
      * Generic getter method for token status
      * @return the status of the defense token
      */
-    public GameConstants.defenseTokenStatus getStatus(){
+    public defenseTokenStatus getStatus(){
         return status;
     }
 
@@ -34,7 +42,7 @@ public class DefenseToken {
      * Generic getter for token type
      * @return the type of defense token
      */
-    public GameConstants.defenseTokenType getType(){
+    public defenseTokenType getType(){
         return type;
     }
 
@@ -43,7 +51,7 @@ public class DefenseToken {
      * @return true if token status is ready, else false
      */
     public boolean isReady(){
-        return (status == GameConstants.defenseTokenStatus.READY);
+        return (status == defenseTokenStatus.READY);
     }
 
     /**
@@ -51,7 +59,7 @@ public class DefenseToken {
      * @return true if token status is exhausted, else false
      */
     public boolean isExhausted(){
-        return (status == GameConstants.defenseTokenStatus.EXHAUSTED);
+        return (status == defenseTokenStatus.EXHAUSTED);
     }
 
     /**
@@ -59,7 +67,7 @@ public class DefenseToken {
      * @return true if token status is discarded, else false
      */
     public boolean isDiscarded(){
-        return (status == GameConstants.defenseTokenStatus.DISCARDED);
+        return (status == defenseTokenStatus.DISCARDED);
     }
 
     /**
@@ -67,7 +75,7 @@ public class DefenseToken {
      * @param status the status of the defense token
      * @return true if token status matches, else false
      */
-    public boolean isStatus(GameConstants.defenseTokenStatus status){
+    public boolean isStatus(defenseTokenStatus status){
         return (this.status == status);
     }
 
@@ -76,7 +84,7 @@ public class DefenseToken {
      * @param type the type of defense token
      * @return true if token is the specified type, else false
      */
-    public boolean isType(GameConstants.defenseTokenType type){
+    public boolean isType(defenseTokenType type){
         return (this.type == type);
     }
 
@@ -87,7 +95,7 @@ public class DefenseToken {
      */
     public boolean exhaust(){
         if(isReady()){
-            status = GameConstants.defenseTokenStatus.EXHAUSTED;
+            status = defenseTokenStatus.EXHAUSTED;
             return true;
         } else {
             return false;
@@ -100,7 +108,7 @@ public class DefenseToken {
      */
     public boolean discard(){
         if(!isDiscarded()){
-            status = GameConstants.defenseTokenStatus.DISCARDED;
+            status = defenseTokenStatus.DISCARDED;
             return true;
         } else {
             return false;
@@ -130,7 +138,7 @@ public class DefenseToken {
      */
     public boolean ready(){
         if(isExhausted()){
-            status = GameConstants.defenseTokenStatus.READY;
+            status = defenseTokenStatus.READY;
             return true;
         } else {
             return false;
@@ -142,11 +150,12 @@ public class DefenseToken {
      */
     public boolean recover(){
         if(isDiscarded()) {
-            status = GameConstants.defenseTokenStatus.READY;
+            status = defenseTokenStatus.READY;
             return true;
         } else {
             return false;
         }
     }
+
 
 }

--- a/tests/DefenseTokenTests.java
+++ b/tests/DefenseTokenTests.java
@@ -1,4 +1,3 @@
-import engine.GameConstants;
 import gameComponents.DefenseTokens.DefenseToken;
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.*;
@@ -7,80 +6,80 @@ public class DefenseTokenTests {
 
     @Test
     public void testConstructor(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
-        assertEquals(GameConstants.defenseTokenType.EVADE, evade.getType());
-        assertEquals(GameConstants.defenseTokenStatus.READY, evade.getStatus());
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        assertEquals(DefenseToken.defenseTokenType.EVADE, evade.getType());
+        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
 
-        DefenseToken brace = new DefenseToken(GameConstants.defenseTokenType.BRACE);
-        assertEquals(GameConstants.defenseTokenType.BRACE, brace.getType());
+        DefenseToken brace = new DefenseToken(DefenseToken.defenseTokenType.BRACE);
+        assertEquals(DefenseToken.defenseTokenType.BRACE, brace.getType());
     }
 
     @Test
     public void testExhaust(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
 
         assertTrue(evade.exhaust());
-        assertEquals(GameConstants.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
 
         assertFalse(evade.exhaust());
-        assertEquals(GameConstants.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
     }
 
     @Test
     public void testDiscard(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
 
         assertTrue(evade.discard());
-        assertEquals(GameConstants.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
 
         assertFalse(evade.discard());
-        assertEquals(GameConstants.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testSpend(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
 
         assertTrue(evade.spend());
-        assertEquals(GameConstants.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
 
         assertTrue(evade.spend());
-        assertEquals(GameConstants.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
 
         assertFalse(evade.spend());
-        assertEquals(GameConstants.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testReady(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
 
         assertFalse(evade.ready());
-        assertEquals(GameConstants.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
 
         evade.exhaust();
         assertTrue(evade.ready());
-        assertEquals(GameConstants.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
 
         evade.discard();
         assertFalse(evade.ready());
-        assertEquals(GameConstants.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testRecover(){
-        DefenseToken evade = new DefenseToken(GameConstants.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
 
         assertFalse(evade.recover());
-        assertEquals(GameConstants.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
 
         evade.exhaust();
         assertFalse(evade.recover());
-        assertEquals(GameConstants.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
 
         evade.discard();
         assertTrue(evade.recover());
-        assertEquals(GameConstants.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
     }
 
 }

--- a/tests/DefenseTokenTests.java
+++ b/tests/DefenseTokenTests.java
@@ -6,80 +6,80 @@ public class DefenseTokenTests {
 
     @Test
     public void testConstructor(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
-        assertEquals(DefenseToken.defenseTokenType.EVADE, evade.getType());
-        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
+        assertEquals(DefenseToken.Type.EVADE, evade.getType());
+        assertEquals(DefenseToken.Status.READY, evade.getStatus());
 
-        DefenseToken brace = new DefenseToken(DefenseToken.defenseTokenType.BRACE);
-        assertEquals(DefenseToken.defenseTokenType.BRACE, brace.getType());
+        DefenseToken brace = new DefenseToken(DefenseToken.Type.BRACE);
+        assertEquals(DefenseToken.Type.BRACE, brace.getType());
     }
 
     @Test
     public void testExhaust(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
 
         assertTrue(evade.exhaust());
-        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.Status.EXHAUSTED, evade.getStatus());
 
         assertFalse(evade.exhaust());
-        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.Status.EXHAUSTED, evade.getStatus());
     }
 
     @Test
     public void testDiscard(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
 
         assertTrue(evade.discard());
-        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.Status.DISCARDED, evade.getStatus());
 
         assertFalse(evade.discard());
-        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.Status.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testSpend(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
 
         assertTrue(evade.spend());
-        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.Status.EXHAUSTED, evade.getStatus());
 
         assertTrue(evade.spend());
-        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.Status.DISCARDED, evade.getStatus());
 
         assertFalse(evade.spend());
-        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.Status.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testReady(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
 
         assertFalse(evade.ready());
-        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.Status.READY, evade.getStatus());
 
         evade.exhaust();
         assertTrue(evade.ready());
-        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.Status.READY, evade.getStatus());
 
         evade.discard();
         assertFalse(evade.ready());
-        assertEquals(DefenseToken.defenseTokenStatus.DISCARDED, evade.getStatus());
+        assertEquals(DefenseToken.Status.DISCARDED, evade.getStatus());
     }
 
     @Test
     public void testRecover(){
-        DefenseToken evade = new DefenseToken(DefenseToken.defenseTokenType.EVADE);
+        DefenseToken evade = new DefenseToken(DefenseToken.Type.EVADE);
 
         assertFalse(evade.recover());
-        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.Status.READY, evade.getStatus());
 
         evade.exhaust();
         assertFalse(evade.recover());
-        assertEquals(DefenseToken.defenseTokenStatus.EXHAUSTED, evade.getStatus());
+        assertEquals(DefenseToken.Status.EXHAUSTED, evade.getStatus());
 
         evade.discard();
         assertTrue(evade.recover());
-        assertEquals(DefenseToken.defenseTokenStatus.READY, evade.getStatus());
+        assertEquals(DefenseToken.Status.READY, evade.getStatus());
     }
 
 }


### PR DESCRIPTION
## Goal of Pull Request
Put defense token simple enums in DefenseToken class instead of GaneConstants

Add JUnit 5.7.0 to the project (even though we already had JUnit 5.4.0 but my computer couldn't tell)

## Potential Tasks

  - [ ] Connects to #65 (partial)
  - [ ] Meets the DefDone of the linked issue (partially)
  - [ ] All tests pass (Although the reviewer should run them to make sure) (For Defense tokens yes)

## Any other pertinent information
What else does the reviewer need to know about?
