### PR TITLE
Ship size enum

### DIFF
--- a/src/gameComponents/Ship/ProtoShip.java
+++ b/src/gameComponents/Ship/ProtoShip.java
@@ -10,42 +10,22 @@ import engine.Utils;
  * bed for building new objects and the like.
  */
 public class ProtoShip {
-    private enum Size {SMALL, MEDIUM, LARGE}
-
     private BBDPoint currentLocation = new BBDPoint(0,0);
     private float orientation = 0f;  //probably degrees
     private final String faction;
-    private final Size size;
+    private final ShipSize size;
     private BBDPolygon cardboard;
     private BBDPolygon plasticBase;
 
-    public ProtoShip(String faction, Size size){
+    public ProtoShip(String faction, ShipSize size){
         this.faction = faction;
         this.size = size;
         buildBase(size);
     }
 
-    private void buildBase(Size size) {
-        switch(size){
-            case SMALL:{
-                this.cardboard = Utils.buildQuad(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH);
-                this.plasticBase = Utils.buildQuad(GameConstants.SHIP_SMALL_WIDTH + GameConstants.SHIP_BASE_RAILS*2,
-                        GameConstants.SHIP_SMALL_LENGTH);
-                break;
-            }
-            case MEDIUM:{
-                this.cardboard = Utils.buildQuad(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH);
-                this.plasticBase = Utils.buildQuad(GameConstants.SHIP_MEDIUM_WIDTH + GameConstants.SHIP_BASE_RAILS*2,
-                        GameConstants.SHIP_MEDIUM_LENGTH);
-                break;
-            }
-            case LARGE:{
-                this.cardboard = Utils.buildQuad(GameConstants.SHIP_LARGE_WIDTH, GameConstants.SHIP_LARGE_LENGTH);
-                this.plasticBase = Utils.buildQuad(GameConstants.SHIP_LARGE_WIDTH + GameConstants.SHIP_BASE_RAILS*2,
-                        GameConstants.SHIP_LARGE_LENGTH);
-                break;
-            }
-        }
+    private void buildBase(ShipSize size) {
+       this.cardboard = size.getCardboard();
+       this.plasticBase = size.getPlastic();
     }
 
 

--- a/src/gameComponents/Ship/ShipSize.java
+++ b/src/gameComponents/Ship/ShipSize.java
@@ -1,0 +1,25 @@
+package gameComponents.Ship;
+
+import BBDGameLibrary.Geometry2d.BBDPolygon;
+import engine.GameConstants;
+import engine.Utils;
+
+public enum ShipSize {
+    SMALL(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
+    MEDIUM(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH),
+    LARGE(GameConstants.SHIP_LARGE_WIDTH, GameConstants.SHIP_LARGE_LENGTH);
+
+    private final float width;
+    private final float length;
+
+    ShipSize(float width, float length){
+        this.width = width;
+        this.length = length;
+    }
+
+    public BBDPolygon getCardboard(){ return Utils.buildQuad(this.width, this.length); }
+
+    public BBDPolygon getPlastic() {
+        return Utils.buildQuad(this.width + 2* GameConstants.SHIP_BASE_RAILS, this.length);
+    }
+}

--- a/src/gameComponents/Ship/ShipSize.java
+++ b/src/gameComponents/Ship/ShipSize.java
@@ -8,6 +8,7 @@ import engine.Utils;
  * An enum for holding the predifined ship sizes and associated logic.
  */
 public enum ShipSize {
+    FLOTILLA(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
     SMALL(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
     MEDIUM(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH),
     LARGE(GameConstants.SHIP_LARGE_WIDTH, GameConstants.SHIP_LARGE_LENGTH);

--- a/src/gameComponents/Ship/ShipSize.java
+++ b/src/gameComponents/Ship/ShipSize.java
@@ -8,17 +8,19 @@ import engine.Utils;
  * An enum for holding the predifined ship sizes and associated logic.
  */
 public enum ShipSize {
-    FLOTILLA(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
-    SMALL(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
-    MEDIUM(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH),
-    LARGE(GameConstants.SHIP_LARGE_WIDTH, GameConstants.SHIP_LARGE_LENGTH);
+    FLOTILLA(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH,1),
+    SMALL(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH,1),
+    MEDIUM(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH,2),
+    LARGE(GameConstants.SHIP_LARGE_WIDTH, GameConstants.SHIP_LARGE_LENGTH,3);
 
     private final float width;
     private final float length;
+    private final int size;
 
-    ShipSize(float width, float length){
+    ShipSize(float width, float length, int size){
         this.width = width;
         this.length = length;
+        this.size = size;
     }
 
     /**
@@ -33,5 +35,14 @@ public enum ShipSize {
      */
     public BBDPolygon getPlastic() {
         return Utils.buildQuad(this.width + 2* GameConstants.SHIP_BASE_RAILS, this.length);
+    }
+
+    /**
+     * Is this ShipSize smaller than another one.  Primarily used for evades and the occasional collision
+     * @param other
+     * @return is this ship smaller than the other one
+     */
+    public boolean isSmaller(ShipSize other){
+        return this.size < other.size;
     }
 }

--- a/src/gameComponents/Ship/ShipSize.java
+++ b/src/gameComponents/Ship/ShipSize.java
@@ -4,6 +4,9 @@ import BBDGameLibrary.Geometry2d.BBDPolygon;
 import engine.GameConstants;
 import engine.Utils;
 
+/**
+ * An enum for holding the predifined ship sizes and associated logic.
+ */
 public enum ShipSize {
     SMALL(GameConstants.SHIP_SMALL_WIDTH, GameConstants.SHIP_SMALL_LENGTH),
     MEDIUM(GameConstants.SHIP_MEDIUM_WIDTH, GameConstants.SHIP_MEDIUM_LENGTH),
@@ -17,8 +20,16 @@ public enum ShipSize {
         this.length = length;
     }
 
+    /**
+     * Get a polygon representing the cardboard rectangle for a ship
+     * @return cardboard
+     */
     public BBDPolygon getCardboard(){ return Utils.buildQuad(this.width, this.length); }
 
+    /**
+     * Get a polygon representing the plastic base of a ship
+     * @return plastic
+     */
     public BBDPolygon getPlastic() {
         return Utils.buildQuad(this.width + 2* GameConstants.SHIP_BASE_RAILS, this.length);
     }


### PR DESCRIPTION
## Goal of Pull Request
Move size of ship to a complex enum to remove size related logic from the ship class.  Since ship sizes never change and come in a handful of predifined configurations, a complex enum makes sense.

## Potential Tasks

  - [ ] Connects to #75 

## Any other pertinent information
None
