### PR TITLE
Separate squadron rendering from squadron component logic

### DIFF
--- a/src/GUI/Board/SquadronRenderer.java
+++ b/src/GUI/Board/SquadronRenderer.java
@@ -1,0 +1,70 @@
+package GUI.Board;
+
+import BBDGameLibrary.GameEngine.GameItem2d;
+import BBDGameLibrary.Geometry2d.BBDPoint;
+import BBDGameLibrary.Geometry2d.BBDPolygon;
+import BBDGameLibrary.OpenGL.Mesh;
+import BBDGameLibrary.OpenGL.ShaderProgram;
+import BBDGameLibrary.OpenGL.Texture;
+import BBDGameLibrary.Utils.GeometryGenerators;
+import BBDGameLibrary.Utils.ShaderPrograms;
+import engine.GameConstants;
+import engine.GameItemSorter;
+import gameComponents.Squadrons.Squadron;
+
+/**
+ * A class to render a squadron object to the board.  This helps keep rendering logic separate from
+ * business logic, enabling us to have cleaner code and unit tests.
+ */
+public class SquadronRenderer {
+
+    private Squadron squadron;
+
+    /**
+     * Static objects to build meshes.  Long term these will be moved somewhere else once rendering is separated from the Squadron object.
+     */
+    private static final BBDPolygon plasticBase = GeometryGenerators.createNGon(new BBDPoint(0,0), GameConstants.SQUADRON_PLASTIC_RADIUS, 100);
+    private static final float[] plasticPositions = Mesh.buildMeshPositions(plasticBase);
+    private static final float[] plasticTex = Mesh.buildTextureCoordinates(plasticBase);
+    private static final int[] plasticIndices = Mesh.buildIndices(plasticBase);
+
+    private static final BBDPolygon cardboard = GeometryGenerators.createNGon(new BBDPoint(0,0), GameConstants.SQUADRON_CARDBOARD_RADIUS, 100);
+    private static final float[] cardboardPositions = Mesh.buildMeshPositions(cardboard);
+    private static final float[] cardboardTex = Mesh.buildTextureCoordinates(cardboard);
+    private static final int[] cardboardIndices = Mesh.buildIndices(cardboard);
+
+    private static final ShaderProgram WHITE_SOLID = ShaderPrograms.buildSolidColorShader("white");
+    private static final ShaderProgram BLACK_SOLID = ShaderPrograms.buildSolidColorShader("black");
+
+    private GameItemSorter gameItems = new GameItemSorter();
+
+
+    public SquadronRenderer(Squadron squadron){
+        this.squadron = squadron;
+        this.buildGameItems();
+    }
+
+    /**
+     * Build the GameItem objects to be used to render this object.
+     */
+    private void buildGameItems(){
+        GameItem2d plasticBaseItem = new GameItem2d(new Mesh(plasticPositions, plasticTex, plasticIndices, null), WHITE_SOLID, plasticBase, GameConstants.LAYER_SQUADRON_PLASTIC, false);
+        GameItem2d cardboardItem = new GameItem2d(new Mesh(cardboardPositions, cardboardTex, cardboardIndices, null), BLACK_SOLID, cardboard, GameConstants.LAYER_SQUADRON_CARDBOARD, false);
+
+        BBDPolygon poly = GeometryGenerators.buildQuad(20, 20);
+        ShaderProgram shader = ShaderPrograms.TEXTURED_GENERIC;
+        Texture texture = new Texture("assets/images/squadrons/squad_"+squadron.buildSquadFileName());
+        GameItem2d squadronGraphic = new GameItem2d(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.LAYER_SQUADRON_GRAPHIC, false);
+        this.gameItems.addItems(squadronGraphic);
+        this.gameItems.addItems(cardboardItem);
+        this.gameItems.addItems(plasticBaseItem);
+    }
+
+
+
+    public GameItemSorter getGameItems() {
+        return gameItems;
+    }
+
+
+}

--- a/src/GUI/Board/SquadronRenderer.java
+++ b/src/GUI/Board/SquadronRenderer.java
@@ -60,7 +60,54 @@ public class SquadronRenderer {
         this.gameItems.addItems(plasticBaseItem);
     }
 
+    /**
+     * Root movement function.  All movement functions eventually lead to here.  Function is private because it is the one
+     * that modifies items of the class.
+     * @param newPoint new BBDPoint to use for the location of the squadron
+     */
+    private void moveNew(BBDPoint newPoint){
+        squadron.moveNew(newPoint);
+        //move the visuals
+        float newX = newPoint.getXLoc();
+        float newY = newPoint.getYLoc();
+        for(int i =0; i<gameItems.getItemCount(); i++){
+            gameItems.getItem(i).setPosition(newX, newY, gameItems.getItem(i).getPosition().z);
+        }
+    }
 
+    /**
+     * Movement function for when we know the relative offset
+     * @param deltaX change in X coordinate
+     * @param deltaY change in Y coordinate
+     */
+    public void moveOffsets(float deltaX, float deltaY){
+        BBDPoint newPoint = squadron.getLocation();
+        newPoint.translate(deltaX, deltaY);
+        moveNew(newPoint);
+    }
+
+    /**
+     * Movement function for when we know angle and distance
+     * @param distance movement length
+     * @param angle angle of movement
+     */
+    public void moveAngle(float distance, float angle){
+        float deltaX = (float) (Math.cos(angle) * distance);
+        float deltaY = (float) (Math.sin(angle) * distance);
+        moveOffsets(deltaX, deltaY);
+    }
+
+    /**
+     * A public facing function to feed into the root movement function.
+     * @param newLocation new location for the squadron
+     */
+    public void relocate(BBDPoint newLocation){
+        moveNew(newLocation);
+    }
+
+    public BBDPoint getLocation(){
+        return squadron.getLocation();
+    }
 
     public GameItemSorter getGameItems() {
         return gameItems;

--- a/src/engine/ArmadaGame.java
+++ b/src/engine/ArmadaGame.java
@@ -57,11 +57,11 @@ public class ArmadaGame implements GameComponent {
         squadrons = new ArrayList<>();
         try {
             SquadronFactory squadronFactory = new SquadronFactory();
-            Squadron temp;
+            SquadronRenderer temp;
             int currentCol = 0;
             int currentRow = 0;
             for (String squadronName : squadronFactory.getSquadronTypes()){
-                temp = squadronFactory.getSquadron(squadronName);
+                temp = new SquadronRenderer(squadronFactory.getSquadron(squadronName));
                 if(currentCol == 10){
                     currentRow++;
                     currentCol=0;
@@ -70,9 +70,8 @@ public class ArmadaGame implements GameComponent {
                 temp.relocate(new BBDPoint(currentCol * 40, currentRow * 40));
                 currentCol++;
                 System.out.println(temp.getLocation());
-                SquadronRenderer renderer = new SquadronRenderer(temp);
-                squadrons.add(renderer);
-                this.itemsToRender.addItems(renderer.getGameItems());
+                squadrons.add(temp);
+                this.itemsToRender.addItems(temp.getGameItems());
             }
 
         } catch (FileNotFoundException e) {

--- a/src/engine/ArmadaGame.java
+++ b/src/engine/ArmadaGame.java
@@ -8,11 +8,13 @@ import BBDGameLibrary.Geometry2d.BBDPolygon;
 import BBDGameLibrary.OpenGL.*;
 import BBDGameLibrary.Utils.GeometryGenerators;
 import BBDGameLibrary.Utils.ShaderPrograms;
+import GUI.Board.SquadronRenderer;
 import engine.parsers.ParsingException;
 import engine.parsers.SquadronFactory;
 import gameComponents.DemoMap;
 import gameComponents.Squadrons.Squadron;
 import org.joml.Vector3f;
+import org.lwjgl.system.CallbackI;
 
 import java.io.FileNotFoundException;
 import java.util.ArrayList;
@@ -29,7 +31,7 @@ public class ArmadaGame implements GameComponent {
     //An object representing the 3x3 mat a demo game is played on
     private DemoMap demoMap;
 
-    private ArrayList<Squadron> squadrons;
+    private ArrayList<SquadronRenderer> squadrons;
     private GameItemSorter itemsToRender = new GameItemSorter();
 
     /**
@@ -68,8 +70,9 @@ public class ArmadaGame implements GameComponent {
                 temp.relocate(new BBDPoint(currentCol * 40, currentRow * 40));
                 currentCol++;
                 System.out.println(temp.getLocation());
-                squadrons.add(temp);
-                this.itemsToRender.addItems(temp.getGameItems());
+                SquadronRenderer renderer = new SquadronRenderer(temp);
+                squadrons.add(renderer);
+                this.itemsToRender.addItems(renderer.getGameItems());
             }
 
         } catch (FileNotFoundException e) {

--- a/src/engine/parsers/ParsingUtils.java
+++ b/src/engine/parsers/ParsingUtils.java
@@ -2,6 +2,7 @@ package engine.parsers;
 
 import engine.GameConstants;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 
 public class ParsingUtils {
@@ -67,10 +68,16 @@ public class ParsingUtils {
         }
     }
 
-    public static void checkNotPartialObject(int nonNullCount, int targetNumber, String name) throws ParsingException {
-        if (nonNullCount != targetNumber){
+    public static void checkNotPartialObject(ArrayList<String> nullFields, int targetNumber, String name) throws ParsingException {
+        if (nullFields.size() != targetNumber){
+            String errorList = "";
+            for (String error : nullFields){
+                errorList = errorList + " " + error +",";
+            }
+            //strip trailing comma
+            errorList = errorList.substring(0, errorList.lastIndexOf(","));
             throw new ParsingException("Reached end of file with a partially built object, " + name +
-                    ", missing " + nonNullCount + " fields.");
+                    ", missing:" + errorList + " fields.");
         }
     }
 }

--- a/src/engine/parsers/ParsingUtils.java
+++ b/src/engine/parsers/ParsingUtils.java
@@ -67,9 +67,10 @@ public class ParsingUtils {
         }
     }
 
-    public static void checkNotPartialObject(int nonNullCount, int targetNumber) throws ParsingException {
+    public static void checkNotPartialObject(int nonNullCount, int targetNumber, String name) throws ParsingException {
         if (nonNullCount != targetNumber){
-            throw new ParsingException("Reached end of file with a partially built object.");
+            throw new ParsingException("Reached end of file with a partially built object, " + name +
+                    ", missing " + nonNullCount + " fields.");
         }
     }
 }

--- a/src/engine/parsers/SquadronFactory.java
+++ b/src/engine/parsers/SquadronFactory.java
@@ -29,25 +29,14 @@ public class SquadronFactory {
 
     private final int NUMBER_OF_FIELDS = 11;
 
-    private boolean renderSquadrons;
-
-    /**
-     * Constructor To be used in a non testing space
-     * @throws FileNotFoundException Exception thrown if the file does not exist
-     * @throws ParsingException Exception thrown if there is an error while Parsing
-     */
-    public SquadronFactory() throws FileNotFoundException, ParsingException {
-        this("assets/data/squadrons.txt", true);
-    }
-
 
     /**
      * Constructor that uses the default file path for the input text doc.  It ends up feeding into the other constructor.
      * @throws FileNotFoundException Exception thrown if the file does not exist
      * @throws ParsingException Exception thrown if there is an error while Parsing
      */
-    public SquadronFactory(boolean renderSquadrons) throws FileNotFoundException, ParsingException {
-        this("assets/data/squadrons.txt", renderSquadrons);
+    public SquadronFactory() throws FileNotFoundException, ParsingException {
+        this("assets/data/squadrons.txt");
     }
 
     /**
@@ -56,8 +45,7 @@ public class SquadronFactory {
      * @throws FileNotFoundException Exception thrown if the file does not exist
      * @throws ParsingException Exception thrown if there is an error while Parsing
      */
-    public SquadronFactory(String pathToFile, boolean renderSquadrons) throws FileNotFoundException, ParsingException {
-        this.renderSquadrons = renderSquadrons;
+    public SquadronFactory(String pathToFile) throws FileNotFoundException, ParsingException {
         Scanner fileScanner = new Scanner(new File(pathToFile));
         String nextLine;
         while(fileScanner.hasNext()){
@@ -198,7 +186,7 @@ public class SquadronFactory {
      */
     public Squadron getSquadron(String name){
         Squadron original = this.squadronMap.get(name);
-        return new Squadron(original, this.renderSquadrons);
+        return new Squadron(original);
     }
 
     /**

--- a/src/engine/parsers/SquadronFactory.java
+++ b/src/engine/parsers/SquadronFactory.java
@@ -25,6 +25,7 @@ public class SquadronFactory {
     private ArrayList<String> keywords;
     private int points;
     private ArrayList<DefenseToken> defenseTokens = null;
+    private String mostRecentlyCompleted = null;
 
     private final int NUMBER_OF_FIELDS = 11;
 
@@ -108,10 +109,11 @@ public class SquadronFactory {
                 } // end switch block
                 if (countNonNullFields() == NUMBER_OF_FIELDS){
                     buildSquadron();
+                    this.mostRecentlyCompleted = this.name;
                 }
             }//end if next line exists
         }//end of while
-        ParsingUtils.checkNotPartialObject(countNonNullFields(), 0);
+        ParsingUtils.checkNotPartialObject(countNonNullFields(), 0, this.mostRecentlyCompleted);
     }
 
     /**

--- a/src/engine/parsers/SquadronFactory.java
+++ b/src/engine/parsers/SquadronFactory.java
@@ -99,21 +99,23 @@ public class SquadronFactory {
 
                         if(!value.equals("None")){
                             String[] defenseTokenArray = value.split(" ");
-                            for(String token: defenseTokenArray){
+                            for(String token: defenseTokenArray) {
                                 ParsingUtils.checkValidDefenseToken(token);
                                 tokens.add(new DefenseToken(token));
                             }
-                        this.defenseTokens = tokens;
                         }
+                        this.defenseTokens = tokens;
                         break;
                 } // end switch block
-                if (countNonNullFields() == NUMBER_OF_FIELDS){
+                ArrayList<String> nulls = listNullFields();
+                if (nulls.size() == 0){
                     buildSquadron();
                     this.mostRecentlyCompleted = this.name;
+                    this.resetFields();
                 }
             }//end if next line exists
         }//end of while
-        ParsingUtils.checkNotPartialObject(countNonNullFields(), 0, this.mostRecentlyCompleted);
+        ParsingUtils.checkNotPartialObject(listNullFields(), NUMBER_OF_FIELDS, this.mostRecentlyCompleted);
     }
 
     /**
@@ -125,8 +127,6 @@ public class SquadronFactory {
         Squadron newSquadron = new Squadron(this.type, this.name, this.unique, this.faction, this.hull, this.speed, this.antiShipDice,
             this.antiSquadronDice, this.keywords, this.points, this.defenseTokens);
         this.squadronMap.put(newSquadron.getName(), newSquadron);
-
-        this.resetFields();
     }
 
     /**
@@ -151,44 +151,44 @@ public class SquadronFactory {
      * parsed at the end of the file.
      * @return
      */
-    private int countNonNullFields() {
-        int nonNullCount = 0;
+    private ArrayList<String> listNullFields() {
+        ArrayList<String> nullFields = new ArrayList<>();
 
-        if(this.name != null){
-            nonNullCount++;
+        if(this.name == null){
+            nullFields.add("name");
         }
-        if(this.unique != null){
-            nonNullCount++;
+        if(this.unique == null){
+            nullFields.add("unique");
         }
-        if(this.type != null){
-            nonNullCount++;
+        if(this.type == null){
+            nullFields.add("type");
         }
-        if(this.faction != null){
-            nonNullCount++;
+        if(this.faction == null){
+            nullFields.add("faction");
         }
-        if(this.antiShipDice != null){
-            nonNullCount++;
+        if(this.antiShipDice == null){
+            nullFields.add("anti-ship dice");
         }
-        if(this.antiSquadronDice != null){
-            nonNullCount++;
+        if(this.antiSquadronDice == null){
+            nullFields.add("anti-squadron dice");
         }
-        if(this.keywords != null){
-            nonNullCount++;
+        if(this.keywords == null){
+            nullFields.add("keywords");
         }
-        if(this.defenseTokens != null){
-            nonNullCount++;
+        if(this.defenseTokens == null){
+            nullFields.add("defense tokens");
         }
-        if(this.hull != 0){
-            nonNullCount++;
+        if(this.hull == 0){
+            nullFields.add("hull");
         }
-        if(this.speed != 0){
-            nonNullCount++;
+        if(this.speed == 0){
+            nullFields.add("speed");
         }
-        if(this.points != 0){
-            nonNullCount++;
+        if(this.points == 0){
+            nullFields.add("points");
         }
 
-        return nonNullCount;
+        return nullFields;
     }
 
     /**

--- a/src/gameComponents/Squadrons/Squadron.java
+++ b/src/gameComponents/Squadrons/Squadron.java
@@ -4,15 +4,7 @@ import BBDGameLibrary.GameEngine.GameComponent;
 import BBDGameLibrary.GameEngine.GameItem2d;
 import BBDGameLibrary.GameEngine.MouseInput;
 import BBDGameLibrary.Geometry2d.BBDPoint;
-import BBDGameLibrary.Geometry2d.BBDPolygon;
-import BBDGameLibrary.OpenGL.Mesh;
-import BBDGameLibrary.OpenGL.ShaderProgram;
-import BBDGameLibrary.OpenGL.Texture;
 import BBDGameLibrary.OpenGL.Window;
-import BBDGameLibrary.Utils.GeometryGenerators;
-import BBDGameLibrary.Utils.ShaderPrograms;
-import engine.GameConstants;
-import engine.GameItemSorter;
 import gameComponents.DefenseTokens.DefenseToken;
 
 import java.util.ArrayList;
@@ -76,7 +68,7 @@ public class Squadron implements GameComponent {
      * being used in the game
      * @param original original Squadron to use as a template
      */
-    public Squadron(Squadron original, boolean renderSquadrons){
+    public Squadron(Squadron original){
         this.type = original.type;
         this.name = original.name;
         this.unique = original.unique;

--- a/src/gameComponents/Squadrons/Squadron.java
+++ b/src/gameComponents/Squadrons/Squadron.java
@@ -22,9 +22,6 @@ import java.util.ArrayList;
  */
 public class Squadron implements GameComponent {
 
-    private static ShaderProgram WHITE_SOLID = ShaderPrograms.buildSolidColorShader("white");
-    private static ShaderProgram BLACK_SOLID = ShaderPrograms.buildSolidColorShader("black");
-
     private final String type;
     private final String name;
     private final boolean unique;
@@ -37,23 +34,9 @@ public class Squadron implements GameComponent {
     private final ArrayList<String> keywords;
     private final int pointsValue;
     private ArrayList<DefenseToken> defenseTokens;
-    private GameItemSorter gameItems = new GameItemSorter();
     private BBDPoint currentLocation = new BBDPoint(0,0);
-    private boolean renderSquadrons;
 
 
-    /**
-     * Static objects to build meshes.  Long term these will be moved somewhere else once rendering is separated from the Squadron object.
-     */
-    private static BBDPolygon plasticBase = GeometryGenerators.createNGon(new BBDPoint(0,0), GameConstants.SQUADRON_PLASTIC_RADIUS, 100);
-    private static float[] plasticPositions = Mesh.buildMeshPositions(plasticBase);
-    private static float[] plasticTex = Mesh.buildTextureCoordinates(plasticBase);
-    private static int[] plasticIndices = Mesh.buildIndices(plasticBase);
-
-    private static BBDPolygon cardboard = GeometryGenerators.createNGon(new BBDPoint(0,0), GameConstants.SQUADRON_CARDBOARD_RADIUS, 100);
-    private static float[] cardboardPositions = Mesh.buildMeshPositions(cardboard);
-    private static float[] cardboardTex = Mesh.buildTextureCoordinates(cardboard);
-    private static int[] cardboardIndices = Mesh.buildIndices(cardboard);
 
 
     /**
@@ -106,11 +89,6 @@ public class Squadron implements GameComponent {
         this.keywords = original.keywords;
         this.pointsValue = original.pointsValue;
         this.defenseTokens = original.defenseTokens;
-        this.renderSquadrons = renderSquadrons;
-
-        if (renderSquadrons) {
-            this.buildGameItems();
-        }
     }
 
     @Override
@@ -139,38 +117,6 @@ public class Squadron implements GameComponent {
     }
 
     /**
-     * Build the GameItem objects to be used to render this object.
-     */
-    private void buildGameItems(){
-        GameItem2d plasticBaseItem = new GameItem2d(new Mesh(plasticPositions, plasticTex, plasticIndices, null), WHITE_SOLID, plasticBase, GameConstants.LAYER_SQUADRON_PLASTIC, false);
-        GameItem2d cardboardItem = new GameItem2d(new Mesh(cardboardPositions, cardboardTex, cardboardIndices, null), BLACK_SOLID, cardboard, GameConstants.LAYER_SQUADRON_CARDBOARD, false);
-
-        BBDPolygon poly = GeometryGenerators.buildQuad(20, 20);
-        ShaderProgram shader = ShaderPrograms.TEXTURED_GENERIC;
-        Texture texture = new Texture("assets/images/squadrons/squad_"+buildSquadFileName());
-        GameItem2d squadronGraphic = new GameItem2d(Mesh.buildMeshFromPolygon(poly, texture), shader, poly, GameConstants.LAYER_SQUADRON_GRAPHIC, false);
-        this.gameItems.addItems(squadronGraphic);
-        this.gameItems.addItems(cardboardItem);
-        this.gameItems.addItems(plasticBaseItem);
-    }
-
-    /**
-     * Build a string based on the squadron object's properties to grab the appropriate descriptively named file.
-     * Concatenates a few fields and cleans up outstanding chars like spaces, quotes etc.
-     * @return image file to be used from the assets directory
-     */
-    public String buildSquadFileName() {
-        String baseFileName = this.type;
-        if(this.unique){
-            baseFileName = baseFileName+"_"+this.name;
-        }
-
-        String cleanedFileName = baseFileName.toLowerCase().replace(" ", "-").replace("\"", "");
-
-        return cleanedFileName+".png";
-    }
-
-    /**
      * Root movement function.  All movement functions eventually lead to here.  Function is private because it is the one
      * that modifies items of the class.
      * @param newPoint new BBDPoint to use for the location of the squadron
@@ -179,9 +125,6 @@ public class Squadron implements GameComponent {
         this.currentLocation = newPoint;
         float newX = newPoint.getXLoc();
         float newY = newPoint.getYLoc();
-        for(int i =0; i<gameItems.getItemCount(); i++){
-            gameItems.getItem(i).setPosition(newX, newY, gameItems.getItem(i).getPosition().z);
-        }
     }
 
     /**
@@ -258,11 +201,23 @@ public class Squadron implements GameComponent {
         return defenseTokens;
     }
 
-    public GameItemSorter getGameItems() {
-        return gameItems;
-    }
-
     public BBDPoint getLocation(){
         return this.currentLocation;
+    }
+
+    /**
+     * Build a string based on the squadron object's properties to grab the appropriate descriptively named file.
+     * Concatenates a few fields and cleans up outstanding chars like spaces, quotes etc.
+     * @return image file to be used from the assets directory
+     */
+    public String buildSquadFileName() {
+        String baseFileName = this.type;
+        if(this.unique){
+            baseFileName = baseFileName+"_"+this.name;
+        }
+
+        String cleanedFileName = baseFileName.toLowerCase().replace(" ", "-").replace("\"", "");
+
+        return cleanedFileName+".png";
     }
 }

--- a/src/gameComponents/Squadrons/Squadron.java
+++ b/src/gameComponents/Squadrons/Squadron.java
@@ -108,46 +108,11 @@ public class Squadron implements GameComponent {
 
     }
 
-    /**
-     * Root movement function.  All movement functions eventually lead to here.  Function is private because it is the one
-     * that modifies items of the class.
-     * @param newPoint new BBDPoint to use for the location of the squadron
-     */
-    private void moveNew(BBDPoint newPoint){
+    public void moveNew(BBDPoint newPoint){
         this.currentLocation = newPoint;
-        float newX = newPoint.getXLoc();
-        float newY = newPoint.getYLoc();
     }
 
-    /**
-     * Movement function for when we know the relative offset
-     * @param deltaX change in X coordinate
-     * @param deltaY change in Y coordinate
-     */
-    public void moveOffsets(float deltaX, float deltaY){
-        this.currentLocation.translate(deltaX, deltaY);
-        //gotta call the private one so that we update the underlying widgets
-        moveNew(this.currentLocation);
-    }
 
-    /**
-     * Movement function for when we know angle and distance
-     * @param distance movement length
-     * @param angle angle of movement
-     */
-    public void moveAngle(float distance, float angle){
-        float deltaX = (float) (Math.cos(angle) * distance);
-        float deltaY = (float) (Math.sin(angle) * distance);
-        moveOffsets(deltaX, deltaY);
-    }
-
-    /**
-     * A public facing function to feed into the root movement function.
-     * @param newLocation new location for the squadron
-     */
-    public void relocate(BBDPoint newLocation){
-        moveNew(newLocation);
-    }
 
     public String getType() {
         return type;

--- a/tests/SquadronTests.java
+++ b/tests/SquadronTests.java
@@ -11,7 +11,7 @@ public class SquadronTests {
 
     @Test
     public void testMoving() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
+        SquadronFactory testParser = new SquadronFactory();
 
         Squadron arc = testParser.getSquadron("ARC-170 Starfighter");
 
@@ -41,7 +41,7 @@ public class SquadronTests {
 
     @Test
     public void testSquadFileNames() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
+        SquadronFactory testParser = new SquadronFactory();
 
         Squadron arc = testParser.getSquadron("ARC-170 Starfighter");
         String expectedFileName = "arc-170-starfighter.png";

--- a/tests/SquadronTests.java
+++ b/tests/SquadronTests.java
@@ -1,7 +1,9 @@
 import BBDGameLibrary.Geometry2d.BBDPoint;
+import GUI.Board.SquadronRenderer;
 import engine.parsers.*;
 import gameComponents.Squadrons.*;
 import org.junit.jupiter.api.Test;
+import org.lwjgl.system.CallbackI;
 
 import java.io.FileNotFoundException;
 
@@ -14,28 +16,29 @@ public class SquadronTests {
         SquadronFactory testParser = new SquadronFactory();
 
         Squadron arc = testParser.getSquadron("ARC-170 Starfighter");
+        SquadronRenderer renderer = new SquadronRenderer(arc);
 
         //test original location
         assertEquals(new BBDPoint(0,0), arc.getLocation());
 
         //test a straight relocate
-        arc.relocate(new BBDPoint(10,10));
+        arc.moveNew(new BBDPoint(10,10));
         assertEquals(new BBDPoint(10,10), arc.getLocation());
-        arc.relocate(new BBDPoint(12,-10));
+        arc.moveNew(new BBDPoint(12,-10));
         assertEquals(new BBDPoint(12,-10), arc.getLocation());
 
         //recenter and test moveOffsets
-        arc.relocate(new BBDPoint(0,0));
-        arc.moveOffsets(10, 1);
+        renderer.relocate(new BBDPoint(0,0));
+        renderer.moveOffsets(10, 1);
         assertEquals(new BBDPoint(10,1), arc.getLocation());
-        arc.moveOffsets(-5,7);
+        renderer.moveOffsets(-5,7);
         assertEquals(new BBDPoint(5,8), arc.getLocation());
 
         //recenter ad test moveAngle
-        arc.relocate(new BBDPoint(0,0));
-        arc.moveAngle(10,0);
+        renderer.relocate(new BBDPoint(0,0));
+        renderer.moveAngle(10,0);
         assertEquals(new BBDPoint(10,0), arc.getLocation());
-        arc.moveAngle(10, (float) (Math.PI/2));
+        renderer.moveAngle(10, (float) (Math.PI/2));
         assertEquals(new BBDPoint(10,10), arc.getLocation());
     }
 

--- a/tests/parsers/SquadronParserTests.java
+++ b/tests/parsers/SquadronParserTests.java
@@ -20,7 +20,7 @@ public class SquadronParserTests {
      */
     @Test
     public void testParseBasicFunctionality() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
+        SquadronFactory testParser = new SquadronFactory();
 
         Squadron arc = testParser.getSquadron("ARC-170 Starfighter");
         assertNotNull(arc);
@@ -41,7 +41,7 @@ public class SquadronParserTests {
 
     @Test
     public void testSquadsActuallyCopies() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
+        SquadronFactory testParser = new SquadronFactory();
         Squadron tie1 = testParser.getSquadron("TIE Fighter");
         Squadron tie2 = testParser.getSquadron("TIE Fighter");
 
@@ -54,7 +54,7 @@ public class SquadronParserTests {
 
     @Test
     public void testDefenseTokenParse() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
+        SquadronFactory testParser = new SquadronFactory();
         Squadron howl = testParser.getSquadron("\"Howlrunner\"");
         assertEquals(2, howl.getDefenseTokens().size());
 
@@ -65,7 +65,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadDefenseTokenParse() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_def_token.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_def_token.txt"));
         String expectedMessage = "Invalid defense token passed in : Derp.";
         String actualMessage = exception.getMessage();
 
@@ -75,7 +75,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadUnique() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_unique.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_unique.txt"));
         String expectedMessage = "Illegal unique value : Maybe.  Legal values are Y and N";
         String actualMessage = exception.getMessage();
 
@@ -84,7 +84,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadFaction() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_faction.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_faction.txt"));
         String expectedMessage = "Illegal faction : Weasel.";
         String actualMessage = exception.getMessage();
 
@@ -93,7 +93,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadHull() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_hull.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_hull.txt"));
         String expectedMessage = "Non integer value found for Hull : Guac.";
         String actualMessage = exception.getMessage();
 
@@ -102,7 +102,7 @@ public class SquadronParserTests {
 
     @Test
     public void testNegativeHull() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_hull_negative.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_hull_negative.txt"));
         String expectedMessage = "Illegal integer value found for Hull : -1.";
         String actualMessage = exception.getMessage();
 
@@ -111,7 +111,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadSpeed() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_speed.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_speed.txt"));
         String expectedMessage = "Non integer value found for Speed : Poodles.";
         String actualMessage = exception.getMessage();
 
@@ -120,7 +120,7 @@ public class SquadronParserTests {
 
     @Test
     public void testNegativeSpeed() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_speed_negative.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_speed_negative.txt"));
         String expectedMessage = "Illegal integer value found for Speed : -1.";
         String actualMessage = exception.getMessage();
 
@@ -129,7 +129,7 @@ public class SquadronParserTests {
 
     @Test
     public void testBadPoints() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_points.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_points.txt"));
         String expectedMessage = "Non integer value found for Points : HarryPotter.";
         String actualMessage = exception.getMessage();
 
@@ -138,7 +138,7 @@ public class SquadronParserTests {
 
     @Test
     public void testNegativePoints() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_points_negative.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_points_negative.txt"));
         String expectedMessage = "Illegal integer value found for Points : -11.";
         String actualMessage = exception.getMessage();
 
@@ -147,7 +147,7 @@ public class SquadronParserTests {
 
     @Test
     public void testNoPipe() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_no_pipe.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_no_pipe.txt"));
         String expectedMessage = "All rows must have 1 '|' character with content both before and after. : UniqueY.";
         String actualMessage = exception.getMessage();
 
@@ -156,7 +156,7 @@ public class SquadronParserTests {
 
     @Test
     public void testExtraPipe() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_extra_pipe.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_extra_pipe.txt"));
         String expectedMessage = "All rows must have 1 '|' character with content both before and after. : SquadType||TIE Interceptor.";
         String actualMessage = exception.getMessage();
 
@@ -165,7 +165,7 @@ public class SquadronParserTests {
 
     @Test
     public void testEdgePipe() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_edge_pipe.txt", false));
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_row_edge_pipe.txt"));
         String expectedMessage = "All rows must have 1 '|' character with content both before and after. : Unique|.";
         String actualMessage = exception.getMessage();
 
@@ -174,8 +174,8 @@ public class SquadronParserTests {
 
     @Test
     public void testPartialSquadron() throws FileNotFoundException, ParsingException {
-        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_partial.txt", false));
-        String expectedMessage = "Reached end of file with a partially built object, null, missing: anti-squadron dice, defense tokens fields.";
+        Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_partial.txt"));
+        String expectedMessage = "Reached end of file with a partially built object, null, missing: anti-squadron dice fields.";
         String actualMessage = exception.getMessage();
 
         assertEquals(expectedMessage, actualMessage);

--- a/tests/parsers/SquadronParserTests.java
+++ b/tests/parsers/SquadronParserTests.java
@@ -65,7 +65,6 @@ public class SquadronParserTests {
 
     @Test
     public void testBadDefenseTokenParse() throws FileNotFoundException, ParsingException {
-        SquadronFactory testParser = new SquadronFactory(false);
         Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_def_token.txt", false));
         String expectedMessage = "Invalid defense token passed in : Derp.";
         String actualMessage = exception.getMessage();
@@ -176,7 +175,7 @@ public class SquadronParserTests {
     @Test
     public void testPartialSquadron() throws FileNotFoundException, ParsingException {
         Exception exception = assertThrows(ParsingException.class, () -> new SquadronFactory("assets/data/test/squadrons_bad_partial.txt", false));
-        String expectedMessage = "Reached end of file with a partially built object.";
+        String expectedMessage = "Reached end of file with a partially built object, null, missing: anti-squadron dice, defense tokens fields.";
         String actualMessage = exception.getMessage();
 
         assertEquals(expectedMessage, actualMessage);


### PR DESCRIPTION
## Goal of Pull Request
Separation of concerns leads to cleaner, easier to maintain code.

Testing "business logic" on a squadron shouldn't require spinning up an OpenGL env around it.

## Potential Tasks
  - [x] Meets the DefDone of the linked issue
  - [x] All tests pass (Although the reviewer should run them to make sure)
  - [x] New Renderer object in a new GUI package
  - [x] Renders squads correctly

## Any other pertinent information
A Squadron Renderer object has a squadron object attached to it.  All user interactions will be with the Renderer, who will pass things to the appropriate function in the squadron object.  Basically a small MVC sort of situation, where the renderer is both V and C.
